### PR TITLE
Json serializable

### DIFF
--- a/src/OGetIt/Common/Alliance.php
+++ b/src/OGetIt/Common/Alliance.php
@@ -19,7 +19,7 @@
  */
 namespace OGetIt\Common;
 
-class Alliance {
+class Alliance implements \JsonSerializable {
 	
 	/**
 	 * @var integer
@@ -58,6 +58,16 @@ class Alliance {
 		
 		return $this->name;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'tag' => $this->tag,
+			'name' => $this->name
+		);
 	}
 	
 }

--- a/src/OGetIt/Common/Coordinates.php
+++ b/src/OGetIt/Common/Coordinates.php
@@ -19,27 +19,27 @@
  */
 namespace OGetIt\Common;
 
-class Coordinates {
+class Coordinates implements \JsonSerializable {
 	
 	/**
 	 * @var string
 	 */
-	private $_coordinates;
+	private $coordinates;
 	
 	/**
 	 * @var integer
 	 */
-	private $_galaxy;
+	private $galaxy;
 
 	/**
 	 * @var integer
 	 */
-	private $_system;
+	private $system;
 
 	/**
 	 * @var integer
 	 */
-	private $_position;
+	private $position;
 	
 	/**
 	 * @param string $type
@@ -47,13 +47,13 @@ class Coordinates {
 	 */
 	public function __construct($coordinates) {
 		
-		$this->_coordinates = $coordinates;
+		$this->coordinates = $coordinates;
 		
 		$coordinatesObject = self::parseCoordinates($coordinates);
 		
-		$this->_galaxy = $coordinatesObject->galaxy;
-		$this->_system = $coordinatesObject->system;
-		$this->_position = $coordinatesObject->position;
+		$this->galaxy = $coordinatesObject->galaxy;
+		$this->system = $coordinatesObject->system;
+		$this->position = $coordinatesObject->position;
 		
 	}
 	
@@ -78,7 +78,7 @@ class Coordinates {
 	 */
 	public function getCoordinates() {
 		
-		return $this->_coordinates;
+		return $this->coordinates;
 		
 	}
 
@@ -87,7 +87,7 @@ class Coordinates {
 	 */
 	public function getGalaxy() {
 		
-		return $this->_galaxy;
+		return $this->galaxy;
 		
 	}
 
@@ -96,7 +96,7 @@ class Coordinates {
 	 */
 	public function getSystem() {
 		
-		return $this->_system;
+		return $this->system;
 		
 	}
 
@@ -105,8 +105,20 @@ class Coordinates {
 	 */
 	public function getPosition() {
 		
-		return $this->_position;
+		return $this->position;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'coordinates' => $this->coordinates,
+			'galaxy' => $this->galaxy,
+			'system' => $this->system,
+			'position' => $this->position
+		);
 	}
 	
 }

--- a/src/OGetIt/Common/DebrisField.php
+++ b/src/OGetIt/Common/DebrisField.php
@@ -19,12 +19,12 @@
  */
 namespace OGetIt\Common;
 
-class DebrisField extends Coordinates {
+class DebrisField extends Coordinates implements \JsonSerializable {
 
 	/**
 	 * @var Resources
 	 */
-	private $_resources;
+	private $resources;
 	
 	/**
 	 * @param string $type
@@ -34,7 +34,7 @@ class DebrisField extends Coordinates {
 		
 		parent::__construct($coordinates);
 
-		$this->_resources = new Resources($metal, $crystal, 0);
+		$this->resources = new Resources($metal, $crystal, 0);
 		
 	}
 	
@@ -43,7 +43,7 @@ class DebrisField extends Coordinates {
 	 */
 	public function getMetal() {
 		
-		return $this->_resources->getMetal();
+		return $this->resources->getMetal();
 		
 	}
 
@@ -52,7 +52,7 @@ class DebrisField extends Coordinates {
 	 */
 	public function getCrystal() {
 		
-		return $this->_resources->getCrystal();
+		return $this->resources->getCrystal();
 		
 	}
 	
@@ -61,8 +61,17 @@ class DebrisField extends Coordinates {
 	 */
 	public function getResources() {
 		
-		return $this->_resources;
+		return $this->resources;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'resources' => $this->resources,
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Common/Planet.php
+++ b/src/OGetIt/Common/Planet.php
@@ -19,7 +19,7 @@
  */
 namespace OGetIt\Common;
 
-class Planet extends Coordinates implements \JsonSerializable {
+class Planet extends Coordinates {
 
 	const	TYPE_PLANET = 1,
 			TYPE_MOON = 3;

--- a/src/OGetIt/Common/Planet.php
+++ b/src/OGetIt/Common/Planet.php
@@ -19,7 +19,7 @@
  */
 namespace OGetIt\Common;
 
-class Planet extends Coordinates {
+class Planet extends Coordinates implements \JsonSerializable {
 
 	const	TYPE_PLANET = 1,
 			TYPE_MOON = 3;
@@ -27,12 +27,12 @@ class Planet extends Coordinates {
 	/**
 	 * @var integer
 	 */
-	private $_type;
+	private $type;
 	
 	/**
 	 * @var string
 	 */
-	private $_name;
+	private $name;
 	/**
 	 * @param string $type
 	 * @param string $coordinates
@@ -41,8 +41,8 @@ class Planet extends Coordinates {
 		
 		parent::__construct($coordinates);
 		
-		$this->_type = $type;
-		$this->_name = $name;
+		$this->type = $type;
+		$this->name = $name;
 		
 	}
 	
@@ -51,7 +51,7 @@ class Planet extends Coordinates {
 	 */
 	public function getType() {
 		
-		return $this->_type;
+		return $this->type;
 		
 	}
 	
@@ -60,8 +60,18 @@ class Planet extends Coordinates {
 	 */
 	public function getName() {
 		
-		return $this->_name;
+		return $this->name;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'type' => $this->type,
+			'name' => $this->name
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Common/PlanetTrait.php
+++ b/src/OGetIt/Common/PlanetTrait.php
@@ -23,14 +23,14 @@ use OGetIt\Common\Planet;
 
 trait PlanetTrait {
 	
-	private $_planet;
+	private $planet;
 	
 	/**
 	 * @param Planet $planet
 	 */
 	public function setPlanet(Planet $planet) {
 		
-		$this->_planet = $planet;
+		$this->planet = $planet;
 		
 	}
 	
@@ -39,7 +39,7 @@ trait PlanetTrait {
 	 */
 	public function getPlanet() {
 		
-		return $this->_planet;
+		return $this->planet;
 		
 	}
 	

--- a/src/OGetIt/Common/Player.php
+++ b/src/OGetIt/Common/Player.php
@@ -19,17 +19,17 @@
  */
 namespace OGetIt\Common;
 
-class Player {
+class Player implements \JsonSerializable {
 	
 	/**
 	 * @var integer
 	 */
-	private $_id;
+	private $id;
 	
 	/**
 	 * @var string
 	 */
-	private $_name;
+	private $name;
 	
 	/**
 	 * @param string $name
@@ -37,8 +37,8 @@ class Player {
 	 */
 	public function __construct($name, $id = null) {
 		
-		$this->_name = $name;
-		$this->_id = $id;
+		$this->name = $name;
+		$this->id = $id;
 		
 	}
 	
@@ -47,7 +47,7 @@ class Player {
 	 */
 	public function getId() {
 		
-		return $this->_id;
+		return $this->id;
 		
 	}
 	
@@ -56,8 +56,18 @@ class Player {
 	 */
 	public function getName() {
 		
-		return $this->_name;
+		return $this->name;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'id' => $this->id,
+			'name' => $this->name
+		);
 	}
 	
 }

--- a/src/OGetIt/Common/Resources.php
+++ b/src/OGetIt/Common/Resources.php
@@ -19,27 +19,27 @@
  */
 namespace OGetIt\Common;
 
-class Resources {
+class Resources implements \JsonSerializable {
 	
 	/**
 	 * @var integer
 	 */
-	private $_metal;
+	private $metal;
 
 	/**
 	 * @var integer
 	 */
-	private $_crystal;
+	private $crystal;
 
 	/**
 	 * @var integer
 	 */
-	private $_deuterium;
+	private $deuterium;
 
 	/**
 	 * @var integer
 	 */	
-	private $_energy;
+	private $energy;
 	
 	/**
 	 * @param integer $metal
@@ -48,10 +48,10 @@ class Resources {
 	 */
 	public function __construct($metal, $crystal, $deuterium, $energy = 0) {
 		
-		$this->_metal = (int)$metal;
-		$this->_crystal = (int)$crystal;
-		$this->_deuterium = (int)$deuterium;
-		$this->_energy = (int)$energy;
+		$this->metal = (int)$metal;
+		$this->crystal = (int)$crystal;
+		$this->deuterium = (int)$deuterium;
+		$this->energy = (int)$energy;
 		
 	}
 	
@@ -60,7 +60,7 @@ class Resources {
 	 */
 	public function getMetal() {
 		
-		return $this->_metal;
+		return $this->metal;
 		
 	}
 
@@ -69,7 +69,7 @@ class Resources {
 	 */
 	public function getCrystal() {
 		
-		return $this->_crystal;
+		return $this->crystal;
 		
 	}
 
@@ -78,7 +78,7 @@ class Resources {
 	 */
 	public function getDeuterium() {
 		
-		return $this->_deuterium;
+		return $this->deuterium;
 		
 	}
 	
@@ -87,7 +87,7 @@ class Resources {
 	 */
 	public function getEnergy() {
 		
-		return $this->_energy;
+		return $this->energy;
 		
 	}
 	
@@ -96,7 +96,7 @@ class Resources {
 	 */
 	public function getTotal() {
 		
-		return $this->_metal + $this->_crystal + $this->_deuterium;
+		return $this->metal + $this->crystal + $this->deuterium;
 		
 	}
 	
@@ -106,10 +106,10 @@ class Resources {
 	 */
 	public function subtract(Resources $resources) {
 		
-		$this->_metal -= $resources->getMetal();
-		$this->_crystal -= $resources->getCrystal();
-		$this->_deuterium -= $resources->getDeuterium();
-		$this->_energy -= $resources->getEnergy();
+		$this->metal -= $resources->getMetal();
+		$this->crystal -= $resources->getCrystal();
+		$this->deuterium -= $resources->getDeuterium();
+		$this->energy -= $resources->getEnergy();
 		
 		return $this;
 		
@@ -121,10 +121,10 @@ class Resources {
 	 */
 	public function add(Resources $resources) {
 		
-		$this->_metal += $resources->getMetal();
-		$this->_crystal += $resources->getCrystal();
-		$this->_deuterium += $resources->getDeuterium();
-		$this->_energy += $resources->getEnergy();
+		$this->metal += $resources->getMetal();
+		$this->crystal += $resources->getCrystal();
+		$this->deuterium += $resources->getDeuterium();
+		$this->energy += $resources->getEnergy();
 		
 		return $this;
 		
@@ -136,13 +136,25 @@ class Resources {
 	 */
 	public function multiply($number) {
 		
-		$this->_metal *= $number;
-		$this->_crystal *= $number;
-		$this->_deuterium *= $number;
-		$this->_energy *= $number;
+		$this->metal *= $number;
+		$this->crystal *= $number;
+		$this->deuterium *= $number;
+		$this->energy *= $number;
 		
 		return $this;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'metal'	=> $this->metal,
+			'crystal' => $this->crystal,
+			'deuterium' => $this->deuterium,
+			'energy' => $this->energy
+		);
 	}
 	
 }

--- a/src/OGetIt/Exception/ApiException.php
+++ b/src/OGetIt/Exception/ApiException.php
@@ -32,7 +32,7 @@ class ApiException extends \Exception {
 	/**
 	 * @var string
 	 */
-	private $_prefix = 'OGame API error: ';
+	private $prefix = 'OGame API error: ';
 	
 	/**
 	 * @param string $message
@@ -73,7 +73,7 @@ class ApiException extends \Exception {
 			
 		}
 		
-		parent::__construct($this->_prefix . $message, $code, $previous);
+		parent::__construct($this->prefix . $message, $code, $previous);
 		
 	}
 	

--- a/src/OGetIt/Exception/CurlException.php
+++ b/src/OGetIt/Exception/CurlException.php
@@ -21,7 +21,7 @@ namespace OGetIt\Exception;
 
 class CurlException extends \Exception {
 	
-	private $_prefix = 'cURL error: ';
+	private $prefix = 'cURL error: ';
 	
 	/**
 	 * @param string $message
@@ -30,7 +30,7 @@ class CurlException extends \Exception {
 	 */
 	public function __construct($message = "Unknown exception", $code = 0, Exception $previous = null) {
 		
-		parent::__construct($this->_prefix . $message, $code, $previous);
+		parent::__construct($this->prefix . $message, $code, $previous);
 		
 	}
 	

--- a/src/OGetIt/Http/HttpRequest.php
+++ b/src/OGetIt/Http/HttpRequest.php
@@ -28,36 +28,36 @@ class HttpRequest {
 	/**
 	 * @var string
 	 */
-	private $_url;
+	private $url;
 	
 	/**
 	 * @var resource
 	 */
-	private $_resource;
+	private $resource;
 	
 	/**
 	 * @var mixed
 	 */
-	private $_response;
+	private $response;
 	
 	/**
 	 * @var boolean|array
 	 */
-	private $_authentication = false;
+	private $authentication = false;
 	
 	/**
 	 * @var integer
 	 */
-	private $_state;
+	private $state;
 	
 	/**
 	 * @param string $url
 	 */
 	public function __construct($url, $connection_timeout = 0) {
 		
-		$this->_url = $url;
-		$this->_state = self::$STATE_OPEN;
-		$this->_resource = curl_init(); 
+		$this->url = $url;
+		$this->state = self::$STATE_OPEN;
+		$this->resource = curl_init(); 
 		$this->setOption(CURLOPT_CONNECTTIMEOUT, $connection_timeout);
 		$this->setOption(CURLOPT_RETURNTRANSFER, true);
 		
@@ -69,19 +69,19 @@ class HttpRequest {
 	 */
 	public function useAuthentication($username, $password) {
 		
-		$this->_authentication = new \stdClass();
-		$this->_authentication->username = $username;
-		$this->_authentication->password = $password;
+		$this->authentication = new \stdClass();
+		$this->authentication->username = $username;
+		$this->authentication->password = $password;
 		
 	}
 	
 	private function handleAuthentication() {
 		
-		if ($this->_authentication !== false) {
-			$this->setOption(CURLOPT_USERPWD, "{$this->_authentication->username}:{$this->_authentication->password}");
+		if ($this->authentication !== false) {
+			$this->setOption(CURLOPT_USERPWD, "{$this->authentication->username}:{$this->authentication->password}");
 		
 			//Clear the htaccess information
-			$this->_authentication = false;
+			$this->authentication = false;
 		}
 		
 	}
@@ -93,7 +93,7 @@ class HttpRequest {
 	 */
 	public function setOption($option, $value) {
 		
-		return curl_setopt($this->_resource, $option, $value);
+		return curl_setopt($this->resource, $option, $value);
 		
 	}
 	
@@ -103,26 +103,26 @@ class HttpRequest {
 	public function send($finish = false) {
 		
 		$this->handleAuthentication();
-		$this->setOption(CURLOPT_URL, $this->_url);
+		$this->setOption(CURLOPT_URL, $this->url);
 		
-		$this->_response = curl_exec($this->_resource);
+		$this->response = curl_exec($this->resource);
 		
 		//If the request fails, save the last error
-		if ($this->_response === false) {
-			throw new CurlException(curl_error($this->_resource), curl_errno($this->_resource));
+		if ($this->response === false) {
+			throw new CurlException(curl_error($this->resource), curl_errno($this->resource));
 		}
 		
 		if ($finish === true) $this->close();
 		
-		return $this->_response;
+		return $this->response;
 		
 	}
 	
 	public function close() {
 		
-		if ($this->_state !== self::$STATE_CLOSED) {
-			$this->_state = self::$STATE_CLOSED;
-			curl_close($this->_resource);
+		if ($this->state !== self::$STATE_CLOSED) {
+			$this->state = self::$STATE_CLOSED;
+			curl_close($this->resource);
 		}
 		
 	}

--- a/src/OGetIt/OGetIt.php
+++ b/src/OGetIt/OGetIt.php
@@ -30,28 +30,28 @@ class OGetIt {
 	/**
 	 * @var integer
 	 */
-	private $_universeID;
+	private $universeID;
 	
 	/**
 	 * @var string
 	 */
-	private $_community;
+	private $community;
 	
 	/**
 	 * @var string
 	 * 
 	 */
-	private $_apikey;
+	private $apikey;
 	
 	/**
 	 * @var string
 	 */
-	private $_version;
+	private $version;
 	
 	/**
 	 * @var boolean
 	 */
-	private $_https = false;
+	private $https = false;
 	
 	/**
 	 * @param integer $universeID
@@ -61,10 +61,10 @@ class OGetIt {
 	 */
 	public function __construct($universeID, $community, $apikey, $version = 'v1') {
 		
-		$this->_universeID 	= $universeID;
-		$this->_community 	= $community;
-		$this->_apikey 		= $apikey;
-		$this->_version 	= $version;
+		$this->universeID 	= $universeID;
+		$this->community 	= $community;
+		$this->apikey 		= $apikey;
+		$this->version 	= $version;
 		
 	}
 	
@@ -86,14 +86,14 @@ class OGetIt {
 	 */
 	public function useHttps() {
 		
-		$this->_https = true;
+		$this->https = true;
 		
 	}
 	
 	private function getApiData($type, $label, $key, $username = false, $password = false) {
 		
 		$url = OGameApi::constructUrl($type, $this, array(
-			'api_key' => $this->_apikey,
+			'api_key' => $this->apikey,
 			$label => $key
 		));
 		
@@ -229,7 +229,7 @@ class OGetIt {
 	 */
 	public function getUniverseID() {
 		
-		return $this->_universeID;
+		return $this->universeID;
 		
 	}
 	
@@ -238,7 +238,7 @@ class OGetIt {
 	 */
 	public function getCommunity() {
 		
-		return $this->_community;
+		return $this->community;
 		
 	}
 	
@@ -247,7 +247,7 @@ class OGetIt {
 	 */
 	public function getApiVersion() {
 		
-		return $this->_version;
+		return $this->version;
 		
 	}
 	
@@ -256,7 +256,7 @@ class OGetIt {
 	 */
 	public function usesHttps() {
 		
-		return $this->_https;
+		return $this->https;
 		
 	}
 		

--- a/src/OGetIt/Report/CombatReport/CombatMoon.php
+++ b/src/OGetIt/Report/CombatReport/CombatMoon.php
@@ -19,7 +19,7 @@
  */
 namespace OGetIt\Report\CombatReport;
 
-class CombatMoon {
+class CombatMoon implements \JsonSerializable {
 
 	/**
 	 * @var integer
@@ -90,6 +90,18 @@ class CombatMoon {
 		
 		return $this->moon_exists;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'change' => $this->moon_chance,
+			'created' => $this->moon_created,
+			'size' => $this->moon_size,
+			'exists' => $this->moon_exists
+		);
 	}
 	
 	

--- a/src/OGetIt/Report/CombatReport/CombatParty.php
+++ b/src/OGetIt/Report/CombatReport/CombatParty.php
@@ -25,39 +25,39 @@ use OGetIt\Report\HarvestReport\HarvestReport;
 use OGetIt\Common\Value\ChildValueAndLosses;
 use OGetIt\Report\CombatReport\Fleet\CombatFleet;
 
-class CombatParty {
+class CombatParty implements \JsonSerializable {
 
 	use ChildValueAndLosses;
 	
 	/**
 	 * @var integer
 	 */
-	private $_count;
+	private $count;
 	
 	/**
 	 * @var integer
 	 */
-	private $_total_losses;
+	private $total_losses;
 
 	/**
 	 * @var integer
 	 */
-	private $_honourable;
+	private $honourable;
 
 	/**
 	 * @var integer
 	 */
-	private $_honourpoints;
+	private $honourpoints;
 	
 	/**
 	 * @var CombatPlayer[]
 	 */
-	private $_players;
+	private $players;
 	
 	/**
 	 * @var HarvestReport[]
 	 */
-	private $_harvestreports = array();
+	private $harvestreports = array();
 	
 	/**
 	 * @param integer $count
@@ -66,10 +66,10 @@ class CombatParty {
 	 */
 	public function __construct($count, $losses, $honourable, $honourpoints) {
 		
-		$this->_count = $count;
-		$this->_total_losses = $losses;
-		$this->_honourable = $honourable;
-		$this->_honourpoints = $honourpoints;
+		$this->count = $count;
+		$this->total_losses = $losses;
+		$this->honourable = $honourable;
+		$this->honourpoints = $honourpoints;
 		
 	}
 	
@@ -78,7 +78,7 @@ class CombatParty {
 	 */
 	public function setPlayers(array $players) {
 		
-		$this->_players = $players;
+		$this->players = $players;
 		
 	}
 
@@ -87,7 +87,7 @@ class CombatParty {
 	 */
 	public function getCount() {
 		
-		return $this->_count;
+		return $this->count;
 		
 	}
 	
@@ -96,7 +96,7 @@ class CombatParty {
 	 */
 	public function getTotalLosses() {
 		
-		return $this->_total_losses;
+		return $this->total_losses;
 		
 	}
 	
@@ -105,7 +105,7 @@ class CombatParty {
 	 */
 	public function getPlayers() {
 		
-		return $this->_players;
+		return $this->players;
 		
 	}
 	
@@ -115,7 +115,7 @@ class CombatParty {
 	 */
 	public function getPlayerByCombatIndex($combat_index) {
 		
-		foreach ($this->_players as $player) {
+		foreach ($this->players as $player) {
 			
 			if ($player->getFleetByCombatIndex($combat_index) !== null) return $player;
 			
@@ -131,7 +131,7 @@ class CombatParty {
 	 */
 	public function getFleetByCombatIndex($combat_index) {
 		
-		foreach ($this->_players as $player) {
+		foreach ($this->players as $player) {
 				
 			if (($fleet = $player->getFleetByCombatIndex($combat_index)) !== null) return $fleet;
 				
@@ -145,7 +145,7 @@ class CombatParty {
 		
 		$players = array();
 		
-		foreach($this->_players as $id => $player) {
+		foreach($this->players as $id => $player) {
 			$players[$id] = clone $player;
 		}
 		
@@ -158,7 +158,7 @@ class CombatParty {
 	 */
 	public function addHarvestReport(HarvestReport $harvestreport) {
 		
-		$this->_harvestreports[] = $harvestreport;
+		$this->harvestreports[] = $harvestreport;
 		
 	}
 	
@@ -167,7 +167,7 @@ class CombatParty {
 	 */
 	public function getHarvestReports() {
 		
-		return $this->_harvestreports;
+		return $this->harvestreports;
 		
 	}
 	
@@ -176,7 +176,7 @@ class CombatParty {
 	 */
 	public function getValue() {
 	
-		return $this->getChildrenValue($this->_players);
+		return $this->getChildrenValue($this->players);
 	
 	}
 	
@@ -185,7 +185,7 @@ class CombatParty {
 	 */
 	public function getLosses() {
 		
-		return $this->getChildrenLosses($this->_players);
+		return $this->getChildrenLosses($this->players);
 		
 	}
 	
@@ -194,7 +194,7 @@ class CombatParty {
 	 */
 	public function getHonourable() {
 		
-		return $this->_honourable;
+		return $this->honourable;
 		
 	}
 	
@@ -203,8 +203,22 @@ class CombatParty {
 	 */
 	public function getHonourPoints() {
 		
-		return $this->_honourpoints;
+		return $this->honourpoints;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'count' => $this->count,
+			'total_losses' => $this->total_losses,
+			'honourable' => $this->honourable,
+			'honourpoints' => $this->honourpoints,
+			'players' => $this->players,
+			'harvestreports' => $this->harvestreports
+		);
 	}
 	
 }

--- a/src/OGetIt/Report/CombatReport/CombatPlayer.php
+++ b/src/OGetIt/Report/CombatReport/CombatPlayer.php
@@ -33,22 +33,22 @@ class CombatPlayer extends Player {
 	/**
 	 * @var integer
 	 */
-	private $_armor;
+	private $armor;
 	
 	/**
 	 * @var integer
 	 */
-	private $_shield;
+	private $shield;
 	
 	/**
 	 * @var integer
 	 */
-	private $_weapon;
+	private $weapon;
 	
 	/**
 	 * @var CombatFleet[]
 	 */
-	private $_fleets = array();
+	private $fleets = array();
 	
 	/**
 	 * @param integer $armor
@@ -57,9 +57,9 @@ class CombatPlayer extends Player {
 	 */
 	public function setCombatTechnologies($armor, $shield, $weapon) {
 	
-		$this->_armor = $armor;
-		$this->_shield = $shield;
-		$this->_weapon = $weapon;
+		$this->armor = $armor;
+		$this->shield = $shield;
+		$this->weapon = $weapon;
 	
 	}
 	
@@ -69,7 +69,7 @@ class CombatPlayer extends Player {
 	public function addFleet(CombatFleet $fleet) {
 	
 		$fleet->setPlayer($this);
-		$this->_fleets[] = $fleet;
+		$this->fleets[] = $fleet;
 	
 	}
 	
@@ -78,9 +78,9 @@ class CombatPlayer extends Player {
 	 */
 	public function updateFleet(CombatFleet $updatedFleet) {
 	
-		foreach ($this->_fleets as $i => $fleet) {
+		foreach ($this->fleets as $i => $fleet) {
 			if ($fleet->getCombatIndex() === $updatedFleet->getCombatIndex()) {
-				$this->_fleets[$i] = $updatedFleet;
+				$this->fleets[$i] = $updatedFleet;
 				break;
 			}
 		}
@@ -93,7 +93,7 @@ class CombatPlayer extends Player {
 	 */
 	public function getFleetByCombatIndex($combat_index) {
 	
-		foreach ($this->_fleets as $fleet) {
+		foreach ($this->fleets as $fleet) {
 	
 			if ($fleet->getCombatIndex() === $combat_index) return $fleet;
 	
@@ -108,7 +108,7 @@ class CombatPlayer extends Player {
 	 */
 	public function getFleets() {
 	
-		return $this->_fleets;
+		return $this->fleets;
 	
 	}
 	
@@ -119,7 +119,7 @@ class CombatPlayer extends Player {
 	
 		$merged = new Fleet();
 	
-		foreach ($this->_fleets as $fleet) {
+		foreach ($this->fleets as $fleet) {
 			$merged->merge($fleet);
 		}
 	
@@ -132,7 +132,7 @@ class CombatPlayer extends Player {
 	 */
 	public function getArmor() {
 	
-		return $this->_armor;
+		return $this->armor;
 	
 	}
 	
@@ -141,7 +141,7 @@ class CombatPlayer extends Player {
 	 */
 	public function getShield() {
 	
-		return $this->_shield;
+		return $this->shield;
 	
 	}
 	
@@ -150,7 +150,7 @@ class CombatPlayer extends Player {
 	 */
 	public function getWeapon() {
 	
-		return $this->_weapon;
+		return $this->weapon;
 	
 	}
 	
@@ -158,13 +158,13 @@ class CombatPlayer extends Player {
 	
 		$fleets = array();
 	
-		foreach ($this->_fleets as $fleet) {
+		foreach ($this->fleets as $fleet) {
 			$clone = clone $fleet;
 			$clone->setPlayer($this);
 			$fleets[] = $clone;
 		}
 	
-		$this->_fleets = $fleets; //Clone the fleets
+		$this->fleets = $fleets; //Clone the fleets
 	
 	}
 	
@@ -173,7 +173,7 @@ class CombatPlayer extends Player {
 	 */
 	public function getValue() {
 	
-		return $this->getChildrenValue($this->_fleets);
+		return $this->getChildrenValue($this->fleets);
 	
 	}
 	
@@ -182,8 +182,21 @@ class CombatPlayer extends Player {
 	 */
 	public function getLosses() {
 		
-		return $this->getChildrenLosses($this->_fleets);
+		return $this->getChildrenLosses($this->fleets);
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'alliance' => $this->alliance,
+			'armor' => $this->armor,
+			'shield' => $this->shield,
+			'weapon' => $this->weapon,
+			'fleets' => $this->fleets
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/CombatReport/CombatReport.php
+++ b/src/OGetIt/Report/CombatReport/CombatReport.php
@@ -39,72 +39,72 @@ class CombatReport extends Report {
 	/**
 	 * @var Planet
 	 */
-	private $_planet;
+	private $planet;
 	
 	/**
 	 * @var integer
 	 */
-	private $_loot_percentage;
+	private $loot_percentage;
 	
 	/**
 	 * @var integer
 	 */
-	private $_combat_rounds_count;
+	private $combat_rounds_count;
 	
 	/**
 	 * @var boolean
 	 */
-	private $_combat_honourable;
+	private $combat_honourable;
 	
 	/**
 	 * @var Resources
 	 */
-	private $_loot;
+	private $loot;
 
 	/**
 	 * @var DebrisField
 	 */
-	private $_debris_field;
+	private $debris_field;
 	
 	/**
 	 * @var string
 	 */
-	private $_winner;
+	private $winner;
 	
 	/**
 	 * @var CombatParty
 	 */
-	private $_attacker_party;
+	private $attacker_party;
 
 	/**
 	 * @var CombatParty
 	 */
-	private $_defender_party;
+	private $defender_party;
 	
 	/**
 	 * @var CombatRound[]
 	 */
-	private $_combat_rounds;
+	private $combat_rounds;
 	
 	/**
 	 * @var CombatReport[]
 	 */
-	private $_raids = array();
+	private $raids = array();
 	
 	/**
 	 * @var CombatReport_Calculator
 	 */
-	private $_combatreport_calculator;
+	private $combatreport_calculator;
 	
 	/**
 	 * @var integer
 	 */
-	private $_player_id_count = 0;
+	private $player_id_count = 0;
 	
 	/**
 	 * @var CombatMoon
 	 */
-	private $_combat_moon;
+	private $combat_moon;
 	
 	/**
 	 * @param string $api_data
@@ -184,21 +184,21 @@ class CombatReport extends Report {
 		
 		parent::__construct($id, $time, $timestamp);
 		
-		$this->_loot_percentage = $loot_percentage;
-		$this->_combat_rounds_count = $combat_rounds;
-		$this->_combat_honourable = $combat_honourable;
-		$this->_winner = $winner;
-		$this->_planet = new Planet($planet_type, $coordinates);
+		$this->loot_percentage = $loot_percentage;
+		$this->combat_rounds_count = $combat_rounds;
+		$this->combat_honourable = $combat_honourable;
+		$this->winner = $winner;
+		$this->planet = new Planet($planet_type, $coordinates);
 		
-		$this->_attacker_party = new CombatParty($attacker_count, $attacker_losses, $attacker_honourable, $attacker_honourpoints);
-		$this->_defender_party = new CombatParty($defender_count, $defender_losses, $defender_honourable, $defender_honourpoints);
+		$this->attacker_party = new CombatParty($attacker_count, $attacker_losses, $attacker_honourable, $attacker_honourpoints);
+		$this->defender_party = new CombatParty($defender_count, $defender_losses, $defender_honourable, $defender_honourpoints);
 		
-		$this->_loot = new Resources($loot_metal, $loot_crystal, $loot_deuterium);
-		$this->_debris_field = new DebrisField($coordinates, $debris_metal, $debris_crystal);
+		$this->loot = new Resources($loot_metal, $loot_crystal, $loot_deuterium);
+		$this->debris_field = new DebrisField($coordinates, $debris_metal, $debris_crystal);
 		
-		$this->_combatreport_calculator = new CombatReport_Calculator($this);
+		$this->combatreport_calculator = new CombatReport_Calculator($this);
 		
-		$this->_combat_moon = new CombatMoon($moon_chance, $moon_created, $moon_exists, $moon_size);
+		$this->combat_moon = new CombatMoon($moon_chance, $moon_created, $moon_exists, $moon_size);
 		
 	}
 	
@@ -209,7 +209,7 @@ class CombatReport extends Report {
 		
 		$players = $this->loadParty($attackers);
 		
-		$this->_attacker_party->setPlayers($players);
+		$this->attacker_party->setPlayers($players);
 		
 	}
 	
@@ -220,7 +220,7 @@ class CombatReport extends Report {
 		
 		$players = $this->loadParty($defenders);
 		
-		$this->_defender_party->setPlayers($players);
+		$this->defender_party->setPlayers($players);
 		
 	}
 	
@@ -239,7 +239,7 @@ class CombatReport extends Report {
 
 			//Check if player already exists, if not create it & add it
 			if ($playerId === false) {
-				$playerId = $this->_player_id_count++;
+				$playerId = $this->player_id_count++;
 				$playerIdMapping[$rawPlayer] = $playerId;
 				$players[$playerId] = new CombatPlayer($rawPlayer, $playerId);
 				$players[$playerId]->setCombatTechnologies(
@@ -281,15 +281,15 @@ class CombatReport extends Report {
 		
 		foreach ($rawRounds as $rawRound) {
 			
-			$this->_combat_rounds[$rawRound['round_number']] = new CombatRound(
+			$this->combat_rounds[$rawRound['round_number']] = new CombatRound(
 				$rawRound['round_number'], 
 				$rawRound['statistics'],
 				$rawRound['attacker_ships'],
 				$rawRound['attacker_ship_losses'],
-				$this->_attacker_party,
+				$this->attacker_party,
 				$rawRound['defender_ships'],
 				$rawRound['defender_ship_losses'],
-				$this->_defender_party
+				$this->defender_party
 			);
 			
 		}		
@@ -301,7 +301,7 @@ class CombatReport extends Report {
 	 */
 	public function getPlanet() {
 		
-		return $this->_planet;
+		return $this->planet;
 		
 	}
 	
@@ -310,7 +310,7 @@ class CombatReport extends Report {
 	 */
 	public function isCombatHonourable() {
 		
-		return $this->_combat_honourable;
+		return $this->combat_honourable;
 		
 	}
 	
@@ -319,7 +319,7 @@ class CombatReport extends Report {
 	 */
 	public function getWinner() {
 		
-		return $this->_winner;
+		return $this->winner;
 		
 	}
 	
@@ -328,7 +328,7 @@ class CombatReport extends Report {
 	 */
 	public function getLootPercentage() {
 		
-		return $this->_loot_percentage;
+		return $this->loot_percentage;
 		
 	}
 	
@@ -337,7 +337,7 @@ class CombatReport extends Report {
 	 */
 	public function getLoot() {
 		
-		return $this->_loot;
+		return $this->loot;
 		
 	}
 	
@@ -346,7 +346,7 @@ class CombatReport extends Report {
 	 */
 	public function getDebrisField() {
 		
-		return $this->_debris_field;
+		return $this->debris_field;
 		
 	}
 
@@ -355,7 +355,7 @@ class CombatReport extends Report {
 	 */
 	public function getAttackerParty() {
 		
-		return $this->_attacker_party;
+		return $this->attacker_party;
 		
 	}
 	
@@ -364,7 +364,7 @@ class CombatReport extends Report {
 	 */
 	public function getDefenderParty() {
 		
-		return $this->_defender_party;
+		return $this->defender_party;
 		
 	}
 	
@@ -373,7 +373,7 @@ class CombatReport extends Report {
 	 */
 	public function getRoundCount() {
 		
-		return $this->_combat_rounds_count;
+		return $this->combat_rounds_count;
 		
 	}
 	
@@ -382,7 +382,7 @@ class CombatReport extends Report {
 	 */
 	public function getRounds() {
 		
-		return $this->_combat_rounds;
+		return $this->combat_rounds;
 		
 	}
 	
@@ -392,7 +392,7 @@ class CombatReport extends Report {
 	 */
 	public function getRound($number) {
 		
-		return isset($this->_combat_rounds[$number]) ? $this->_combat_rounds[$number] : null;
+		return isset($this->combat_rounds[$number]) ? $this->combat_rounds[$number] : null;
 		
 	}
 	
@@ -404,7 +404,7 @@ class CombatReport extends Report {
 		
 		if ($raid->getPlanet()->getCoordinates() !== $this->getPlanet()->getCoordinates()) return false;
 		
-		$this->_raids[] = $raid;
+		$this->raids[] = $raid;
 		
 		return true;
 		
@@ -415,7 +415,7 @@ class CombatReport extends Report {
 	 */
 	public function getRaids() {
 		
-		return $this->_raids;
+		return $this->raids;
 		
 	}
 	
@@ -424,7 +424,7 @@ class CombatReport extends Report {
 	 */
 	public function hasRaids() {
 		
-		return !empty($this->_raids);
+		return !empty($this->raids);
 		
 	}
 	
@@ -433,7 +433,7 @@ class CombatReport extends Report {
 	 */
 	public function getCalculator() {
 		
-		return $this->_combatreport_calculator;
+		return $this->combatreport_calculator;
 		
 	}
 	
@@ -442,8 +442,29 @@ class CombatReport extends Report {
 	 */
 	public function getCombatMoon() {
 		
-		return $this->_combat_moon;
+		return $this->combat_moon;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'planet' => $this->planet,
+			'loot_percentage' => $this->loot_percentage,
+			'combat_rounds_count' => $this->combat_rounds_count,
+			'combat_honourable' => $this->combat_honourable,
+			'loot' => $this->loot,
+			'debris_field' => $this->debris_field,
+			'winner' => $this->winner,
+			'attacker_party' => $this->attacker_party,
+			'defender_party' => $this->defender_party,
+			'combat_rounds' => $this->combat_rounds,
+			'raids' => $this->raids,
+			'player_id_count' => $this->player_id_count,
+			'combat_moon' => $this->combat_moon,
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/CombatReport/CombatReport_Calculator.php
+++ b/src/OGetIt/Report/CombatReport/CombatReport_Calculator.php
@@ -28,14 +28,14 @@ class CombatReport_Calculator {
 	/**
 	 * @var CombatReport
 	 */
-	private $_combatreport;
+	private $combatreport;
 	
 	/**
 	 * @param CombatReport $combatreport
 	 */
 	public function __construct(CombatReport $combatreport) {
 		
-		$this->_combatreport = $combatreport;
+		$this->combatreport = $combatreport;
 		
 	}
 	
@@ -47,7 +47,7 @@ class CombatReport_Calculator {
 	 */
 	public function getRoundDifference($startRound, $endRound) {
 		
-		return CombatResult_RoundDifference::calculate($this->_combatreport, $startRound, $endRound);
+		return CombatResult_RoundDifference::calculate($this->combatreport, $startRound, $endRound);
 		
 	}
 	
@@ -56,7 +56,7 @@ class CombatReport_Calculator {
 	 */
 	public function getFinalResult() {
 		
-		return $this->getRoundDifference(0, $this->_combatreport->getRoundCount());
+		return $this->getRoundDifference(0, $this->combatreport->getRoundCount());
 		
 	}
 	

--- a/src/OGetIt/Report/CombatReport/Fleet/CombatFleet.php
+++ b/src/OGetIt/Report/CombatReport/Fleet/CombatFleet.php
@@ -36,7 +36,7 @@ class CombatFleet extends Fleet {
 	/**
 	 * @var integer
 	 */
-	private $_combat_index;
+	private $combat_index;
 	
 	/**
 	 * @param Planet $planet
@@ -45,7 +45,7 @@ class CombatFleet extends Fleet {
 	public function __construct(Planet $planet, $combat_index) {
 		
 		$this->setPlanet($planet);
-		$this->_combat_index = $combat_index;
+		$this->combat_index = $combat_index;
 		
 	}
 	
@@ -54,8 +54,18 @@ class CombatFleet extends Fleet {
 	 */
 	public function getCombatIndex() {
 		
-		return $this->_combat_index;
+		return $this->combat_index;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'planet' => $this->planet,
+			'combat_index' => $this->combat_index
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/CombatReport/Fleet/Fleet.php
+++ b/src/OGetIt/Report/CombatReport/Fleet/Fleet.php
@@ -27,19 +27,19 @@ use OGetIt\Report\CombatReport\CombatPlayer;
 use OGetIt\Technology\State\StateCombatWithLosses;
 use OGetIt\Common\Value\ChildValueAndLosses;
 
-class Fleet {
+class Fleet implements \JsonSerializable {
 	
 	use ChildValueAndLosses;
 	
 	/**
 	 * @var CombatPlayer
 	 */
-	private $_player;
+	private $player;
 	
 	/**
 	 * @var StateCombatWithLosses[] 
 	 */
-	private $_state = array();
+	private $state = array();
 	
 	/**
 	 * @param Technology $technology
@@ -48,11 +48,11 @@ class Fleet {
 	 */
 	public function addTechnologyState($technology, $count, $lost = false) {
 		
-		if (isset($this->_state[$technology->getType()])) {
+		if (isset($this->state[$technology->getType()])) {
 			
-			$this->_state[$technology->getType()]->addCount($count);
+			$this->state[$technology->getType()]->addCount($count);
 			if ($lost !== false) {
-				$this->_state[$technology->getType()]->addLost($lost);
+				$this->state[$technology->getType()]->addLost($lost);
 			}
 			
 		} else {
@@ -63,7 +63,7 @@ class Fleet {
 				$lost
 			);
 			
-			$this->_state[$technology->getType()] = $techState;
+			$this->state[$technology->getType()] = $techState;
 			
 		}
 		
@@ -75,7 +75,7 @@ class Fleet {
 	 */
 	public function getTechnologyState($type) {
 		
-		return isset($this->_state[$type]) ? $this->_state[$type] : null;
+		return isset($this->state[$type]) ? $this->state[$type] : null;
 		
 	}
 	
@@ -84,7 +84,7 @@ class Fleet {
 	 */
 	public function getTechnologyStates() {
 		
-		return $this->_state;
+		return $this->state;
 		
 	}
 	
@@ -93,7 +93,7 @@ class Fleet {
 	 */
 	public function setPlayer(CombatPlayer $player) {
 		
-		$this->_player = $player;
+		$this->player = $player;
 		
 	}
 	
@@ -102,14 +102,14 @@ class Fleet {
 	 */
 	public function getPlayer() {
 		
-		return $this->_player;
+		return $this->player;
 		
 	}
 	
 
 	public function __clone() {
 	
-		$this->_state = array(); //Clear state
+		$this->state = array(); //Clear state
 	
 	}
 	
@@ -135,7 +135,7 @@ class Fleet {
 	 */
 	public function getValue() {
 	
-		return $this->getChildrenValue($this->_state);
+		return $this->getChildrenValue($this->state);
 	
 	}
 	
@@ -144,7 +144,7 @@ class Fleet {
 	 */
 	public function getLosses() {
 		
-		return $this->getChildrenLosses($this->_state);
+		return $this->getChildrenLosses($this->state);
 		
 	}
 	
@@ -156,7 +156,7 @@ class Fleet {
 		
 		$fleet = clone $other;
 		
-		foreach ($this->_state as $type => $techState) {
+		foreach ($this->state as $type => $techState) {
 			
 			$count = $other->getTechnologyState($type) !== null ? $other->getTechnologyState($type)->getCount() : 0;
 			$lost = $techState->getCount() - $count;
@@ -167,6 +167,16 @@ class Fleet {
 		
 		return $fleet;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			//Don't add player, this will create recursion
+			'state' => $this->state
+		);
 	}
 	
 }

--- a/src/OGetIt/Report/CombatReport/Result/CombatResult_RoundDifference.php
+++ b/src/OGetIt/Report/CombatReport/Result/CombatResult_RoundDifference.php
@@ -26,7 +26,7 @@ use OGetIt\Report\CombatReport\CombatReport;
 use OGetIt\Report\CombatReport\CombatPlayer;
 use OGetIt\Report\CombatReport\CombatParty;
 
-class CombatResult_RoundDifference {
+class CombatResult_RoundDifference implements \JsonSerializable {
 	
 	/**
 	 * @var CombatParty[]
@@ -136,6 +136,16 @@ class CombatResult_RoundDifference {
 		
 		return $this->defenders;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'attackers' => $this->attackers,
+			'defenders' => $this->defenders,
+		);
 	}
 	
 }

--- a/src/OGetIt/Report/CombatReport/Round/CombatRound.php
+++ b/src/OGetIt/Report/CombatReport/Round/CombatRound.php
@@ -25,27 +25,27 @@ use OGetIt\Common\Player;
 use OGetIt\Technology\TechnologyFactory;
 use OGetIt\Report\CombatReport\CombatPlayer;
 
-class CombatRound {
+class CombatRound implements \JsonSerializable {
 		
 	/**
 	 * @var integer
 	 */
-	private $_number;
+	private $number;
 	
 	/**
 	 * @var CombatRound_Stats
 	 */
-	private $_statistics;
+	private $statistics;
 	
 	/** 
 	 * @var CombatPlayer[]
 	 */
-	private $_attacker_fleet_details;
+	private $attacker_fleet_details;
 
 	/**
 	 * @var CombatPlayer[]
 	 */
-	private $_defender_fleet_details;
+	private $defender_fleet_details;
 
 	/**
 	 * @param integer $number
@@ -59,12 +59,12 @@ class CombatRound {
 	 */
 	public function __construct($number, $statistics, $attacker_ships, $attacker_ship_losses, $attacker_party, $defender_ships, $defender_ship_losses, $defender_party) {
 		
-		$this->_number = $number;
+		$this->number = $number;
 		
-		$this->_statistics = CombatRound_Stats::createInstance($statistics);
+		$this->statistics = CombatRound_Stats::createInstance($statistics);
 
-		$this->_attacker_fleet_details = $this->loadFleetDetails($attacker_ships, $attacker_ship_losses, $attacker_party);
-		$this->_defender_fleet_details = $this->loadFleetDetails($defender_ships, $defender_ship_losses, $defender_party);
+		$this->attacker_fleet_details = $this->loadFleetDetails($attacker_ships, $attacker_ship_losses, $attacker_party);
+		$this->defender_fleet_details = $this->loadFleetDetails($defender_ships, $defender_ship_losses, $defender_party);
 		
 	}
 	
@@ -144,7 +144,7 @@ class CombatRound {
 	 */
 	public function getNumber() {
 		
-		return $this->_number;
+		return $this->number;
 		
 	}
 	
@@ -153,7 +153,7 @@ class CombatRound {
 	 */
 	public function getStatistics() {
 		
-		return $this->_statistics;
+		return $this->statistics;
 		
 	}
 	
@@ -162,7 +162,7 @@ class CombatRound {
 	 */
 	public function getAttackersDetails() {
 		
-		return $this->_attacker_fleet_details;
+		return $this->attacker_fleet_details;
 		
 	}
 	
@@ -171,8 +171,20 @@ class CombatRound {
 	 */
 	public function getDefendersDetails() {
 		
-		return $this->_defender_fleet_details;
+		return $this->defender_fleet_details;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'number' => $this->number,
+			'statistics' => $this->statistics,
+			'attacker_fleet_details' => $this->attacker_fleet_details,
+			'defender_fleet_details' => $this->defender_fleet_details
+		);
 	}
 		
 }

--- a/src/OGetIt/Report/CombatReport/Round/CombatRound_Stats.php
+++ b/src/OGetIt/Report/CombatReport/Round/CombatRound_Stats.php
@@ -19,37 +19,37 @@
  */
 namespace OGetIt\Report\CombatReport\Round;
 
-class CombatRound_Stats {
+class CombatRound_Stats implements \JsonSerializable {
 		
 	/**
 	 * @var integer
 	 */
-	private $_attacker_hits;
+	private $attacker_hits;
 
 	/**
 	 * @var integer
 	 */
-	private $_attacker_absorbed;	
+	private $attacker_absorbed;	
 	
 	/**
 	 * @var integer
 	 */
-	private $_attacker_fullstrength;	
+	private $attacker_fullstrength;	
 	
 	/**
 	 * @var integer
 	 */
-	private $_defender_hits;	
+	private $defender_hits;	
 	
 	/**
 	 * @var integer
 	 */
-	private $_defender_absorbed;	
+	private $defender_absorbed;	
 	
 	/**
 	 * @var integer
 	 */
-	private $_defender_fullstrength;
+	private $defender_fullstrength;
 
 	/**
 	 * @param array $data
@@ -80,13 +80,13 @@ class CombatRound_Stats {
 	 */
 	public function __construct($attacker_hits, $attacker_absorbed, $attacker_fullstrength, $defender_hits, $defender_absorbed, $defender_absorbed, $defender_fullstrength) {
 		
-		$this->_attacker_hits = $attacker_hits;
-		$this->_attacker_absorbed = $attacker_absorbed;
-		$this->_attacker_fullstrength = $attacker_fullstrength;
+		$this->attacker_hits = $attacker_hits;
+		$this->attacker_absorbed = $attacker_absorbed;
+		$this->attacker_fullstrength = $attacker_fullstrength;
 		
-		$this->_defender_hits = $defender_hits;
-		$this->_defender_absorbed = $defender_absorbed;
-		$this->_defender_fullstrength = $defender_fullstrength;
+		$this->defender_hits = $defender_hits;
+		$this->defender_absorbed = $defender_absorbed;
+		$this->defender_fullstrength = $defender_fullstrength;
 
 	}
 
@@ -95,7 +95,7 @@ class CombatRound_Stats {
 	 */
 	public function getAttackerHits() {
 		
-		return $this->_attacker_hits;
+		return $this->attacker_hits;
 		
 	}
 
@@ -104,7 +104,7 @@ class CombatRound_Stats {
 	 */
 	public function getAttackerAbsorbed() {
 		
-		return $this->_attacker_absorbed;
+		return $this->attacker_absorbed;
 		
 	}
 
@@ -113,7 +113,7 @@ class CombatRound_Stats {
 	 */
 	public function getAttackerFullStrength() {
 		
-		return $this->_attacker_fullstrength;
+		return $this->attacker_fullstrength;
 		
 	}
 
@@ -122,7 +122,7 @@ class CombatRound_Stats {
 	 */
 	public function getDefenderHits() {
 		
-		return $this->_defender_hits;
+		return $this->defender_hits;
 		
 	}
 
@@ -131,7 +131,7 @@ class CombatRound_Stats {
 	 */
 	public function getDefenderAbsorbed() {
 		
-		return $this->_defender_absorbed;
+		return $this->defender_absorbed;
 		
 	}
 	
@@ -140,8 +140,22 @@ class CombatRound_Stats {
 	 */
 	public function getDefenderFullStrength() {
 		
-		return $this->_defender_fullstrength;
+		return $this->defender_fullstrength;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'attacker_hits' => $this->attacker_hits,
+			'attacker_absorbed' => $this->attacker_absorbed,
+			'attacker_fullstrength' => $this->attacker_fullstrength,
+			'defender_hits' => $this->defender_hits,
+			'defender_absorbed' => $this->defender_absorbed,
+			'defender_fullstrength' => $this->defender_fullstrength,
+		);
 	}
 		
 }

--- a/src/OGetIt/Report/HarvestReport/HarvestReport.php
+++ b/src/OGetIt/Report/HarvestReport/HarvestReport.php
@@ -23,22 +23,22 @@ use OGetIt\Common\Resources;
 use OGetIt\Common\DebrisField;
 use OGetIt\Report\Report;
 
-class HarvestReport extends Report {
+class HarvestReport extends Report implements \JsonSerializable {
 
 	/**
 	 * @var DebrisField
 	 */
-	private $_debris_field;
+	private $debris_field;
 	
 	/**
 	 * @var integer
 	 */
-	private $_recycler_capacity;
+	private $recycler_capacity;
 	
 	/**
 	 * @var integer
 	 */
-	private $_recycler_count;
+	private $recycler_count;
 	
 	/**
 	 * @param string $api_data
@@ -81,11 +81,11 @@ class HarvestReport extends Report {
 		
 		parent::__construct($id, $time, $timestamp);
 		
-		$this->_resources = new Resources($metal, $crystal, 0);
-		$this->_recycler_capacity = (int)$recycler_capacity;
-		$this->_recycler_count = (int)$recycler_count;
+		$this->resources = new Resources($metal, $crystal, 0);
+		$this->recycler_capacity = (int)$recycler_capacity;
+		$this->recycler_count = (int)$recycler_count;
 		
-		$this->_debris_field = new DebrisField($coordinates, $metal_floating, $crystal_floating);
+		$this->debris_field = new DebrisField($coordinates, $metal_floating, $crystal_floating);
 		
 	}
 	
@@ -94,7 +94,7 @@ class HarvestReport extends Report {
 	 */
 	public function getMetal() {
 		
-		return $this->_resources->getMetal();
+		return $this->resources->getMetal();
 		
 	}
 
@@ -103,7 +103,7 @@ class HarvestReport extends Report {
 	 */
 	public function getCrystal() {
 		
-		return $this->_resources->getCrystal();
+		return $this->resources->getCrystal();
 		
 	}
 	
@@ -112,7 +112,7 @@ class HarvestReport extends Report {
 	 */
 	public function getResources() {
 		
-		return $this->_resources;
+		return $this->resources;
 		
 	}
 	
@@ -121,7 +121,7 @@ class HarvestReport extends Report {
 	 */
 	public function getDebrisField() {
 		
-		return $this->_debris_field;
+		return $this->debris_field;
 		
 	}
 	
@@ -130,7 +130,7 @@ class HarvestReport extends Report {
 	 */
 	public function getRecyclerCapacity() {
 		
-		return $this->_recycler_capacity;
+		return $this->recycler_capacity;
 		
 	}
 	
@@ -139,8 +139,18 @@ class HarvestReport extends Report {
 	 */
 	public function getRecyclerCount() {
 		
-		return $this->_recycler_count;
+		return $this->recycler_count;
 		
+	}
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'debris_field' => $this->debris_field,
+			'recycler_capacity' => $this->recycler_capacity,
+			'recycler_count' => $this->recycler_count
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/HarvestReport/HarvestReport.php
+++ b/src/OGetIt/Report/HarvestReport/HarvestReport.php
@@ -23,7 +23,7 @@ use OGetIt\Common\Resources;
 use OGetIt\Common\DebrisField;
 use OGetIt\Report\Report;
 
-class HarvestReport extends Report implements \JsonSerializable {
+class HarvestReport extends Report {
 
 	/**
 	 * @var DebrisField

--- a/src/OGetIt/Report/MissileReport/MissilePlayer.php
+++ b/src/OGetIt/Report/MissileReport/MissilePlayer.php
@@ -25,21 +25,21 @@ use OGetIt\Technology\State\StateCombatWithLosses;
 use OGetIt\Common\Value\ChildValueAndLosses;
 use OGetIt\Common\Resources;
 
-class MissilePlayer extends ReportPlayer {
+class MissilePlayer extends ReportPlayer implements \JsonSerializable {
 
 	use ChildValueAndLosses;
 	
 	/**
 	 * @var StateCombatWithLosses[]
 	 */
-	private $_defence = array();
+	private $defence = array();
 	
 	/**
 	 * @param StateCombatWithLosses $entityState
 	 */
 	public function addLostDefence(StateCombatWithLosses $entityState) {
 	
-		$this->_defence[$entityState->getTechnology()->getType()] = $entityState;
+		$this->defence[$entityState->getTechnology()->getType()] = $entityState;
 	
 	}
 	
@@ -48,7 +48,7 @@ class MissilePlayer extends ReportPlayer {
 	 */
 	public function getLostDefence() {
 	
-		return $this->_defence;
+		return $this->defence;
 	
 	}
 	
@@ -57,7 +57,7 @@ class MissilePlayer extends ReportPlayer {
 	 */
 	public function getValue() {
 		
-		return $this->getChildrenValue($this->_defence);
+		return $this->getChildrenValue($this->defence);
 		
 	}
 	
@@ -66,8 +66,17 @@ class MissilePlayer extends ReportPlayer {
 	 */
 	public function getLosses() {
 		
-		return $this->getChildrenLosses($this->_defence);
+		return $this->getChildrenLosses($this->defence);
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'defence' => $this->defence
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/MissileReport/MissilePlayer.php
+++ b/src/OGetIt/Report/MissileReport/MissilePlayer.php
@@ -25,7 +25,7 @@ use OGetIt\Technology\State\StateCombatWithLosses;
 use OGetIt\Common\Value\ChildValueAndLosses;
 use OGetIt\Common\Resources;
 
-class MissilePlayer extends ReportPlayer implements \JsonSerializable {
+class MissilePlayer extends ReportPlayer {
 
 	use ChildValueAndLosses;
 	

--- a/src/OGetIt/Report/MissileReport/MissileReport.php
+++ b/src/OGetIt/Report/MissileReport/MissileReport.php
@@ -27,7 +27,7 @@ use OGetIt\Technology\TechnologyFactory;
 use OGetIt\Technology\State\StateCombatWithLosses;
 use OGetIt\Technology\Entity\Defence\InterplanetaryMissile;
 
-class MissileReport extends Report implements \JsonSerializable {
+class MissileReport extends Report {
 	
 	/**
 	 * @var MissilePlayer

--- a/src/OGetIt/Report/MissileReport/MissileReport.php
+++ b/src/OGetIt/Report/MissileReport/MissileReport.php
@@ -27,7 +27,7 @@ use OGetIt\Technology\TechnologyFactory;
 use OGetIt\Technology\State\StateCombatWithLosses;
 use OGetIt\Technology\Entity\Defence\InterplanetaryMissile;
 
-class MissileReport extends Report {
+class MissileReport extends Report implements \JsonSerializable {
 	
 	/**
 	 * @var MissilePlayer
@@ -171,6 +171,18 @@ class MissileReport extends Report {
 		
 		return $this->defender_lost_missiles;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'attacker' => $this->attacker,
+			'attacker_lost_missiles' => $this->attacker_lost_missiles,
+			'defender' => $this->defender,
+			'defender_lost_missiles' => $this->defender_lost_missiles
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/Report.php
+++ b/src/OGetIt/Report/Report.php
@@ -19,31 +19,31 @@
  */
 namespace OGetIt\Report;
 
-abstract class Report {
+abstract class Report implements \JsonSerializable {
 
 	/**
 	 * @var string
 	 */
-	private $_id;
+	private $id;
 	
 	/**
 	 * @var string
 	 */
-	private $_time;
+	private $time;
 	
 	/**
 	 * @var integer
 	 */
-	private $_timestamp;
+	private $timestamp;
 	
 	/**
 	 * @param string $id
 	 */
 	public function __construct($id, $time, $timestamp) {
 		
-		$this->_id = $id;
-		$this->_time = $time;
-		$this->_timestamp = $timestamp;
+		$this->id = $id;
+		$this->time = $time;
+		$this->timestamp = $timestamp;
 		
 	}
 	
@@ -52,7 +52,7 @@ abstract class Report {
 	 */
 	public function getId() {
 		
-		return $this->_id;
+		return $this->id;
 		
 	}
 	
@@ -61,7 +61,7 @@ abstract class Report {
 	 */
 	public function getTime() {
 		
-		return $this->_time;
+		return $this->time;
 		
 	}
 	
@@ -70,8 +70,19 @@ abstract class Report {
 	 */
 	public function getTimestamp() {
 		
-		return $this->_timestamp;
+		return $this->timestamp;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'id' => $this->id,
+			'time' => $this->time,
+			'timestamp' => $this->timestamp
+		);
 	}
 	
 }

--- a/src/OGetIt/Report/ReportPlayer.php
+++ b/src/OGetIt/Report/ReportPlayer.php
@@ -23,9 +23,19 @@ use OGetIt\Common\Player;
 use OGetIt\Common\PlanetTrait;
 use OGetIt\Common\AllianceTrait;
 
-class ReportPlayer extends Player {
+class ReportPlayer extends Player implements \JsonSerializable {
 	
 	use PlanetTrait;
 	use AllianceTrait;
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'planet' => $this->planet,
+			'alliance' => $this->alliance
+		), parent::jsonSerialize());
+	}
 	
 }

--- a/src/OGetIt/Report/ReportPlayer.php
+++ b/src/OGetIt/Report/ReportPlayer.php
@@ -23,7 +23,7 @@ use OGetIt\Common\Player;
 use OGetIt\Common\PlanetTrait;
 use OGetIt\Common\AllianceTrait;
 
-class ReportPlayer extends Player implements \JsonSerializable {
+class ReportPlayer extends Player {
 	
 	use PlanetTrait;
 	use AllianceTrait;

--- a/src/OGetIt/Report/SpyReport/SpiedPlayer.php
+++ b/src/OGetIt/Report/SpyReport/SpiedPlayer.php
@@ -26,39 +26,39 @@ use OGetIt\Technology\State\StateEconomy;
 use OGetIt\Technology\State\StateCombat;
 use OGetIt\Report\ReportPlayer;
 
-class SpiedPlayer extends ReportPlayer {
+class SpiedPlayer extends ReportPlayer implements \JsonSerializable {
 		
 	/**
 	 * @var Resources
 	 */
-	private $_resources;
+	private $resources;
 	
 	/**
 	 * @var StateEconomy[]
 	 */
-	private $_buildings = array();
+	private $buildings = array();
 	
 	/**
 	 * @var StateEconomy[]
 	 */
-	private $_research = array();
+	private $research = array();
 
 	/**
 	 * @var StateCombat[]
 	 */
-	private $_ships = array();
+	private $ships = array();
 	
 	/**
 	 * @var StateCombat[]
 	 */
-	private $_defence = array();
+	private $defence = array();
 	
 	/**
 	 * @param Resources $resources
 	 */
 	public function setResources(Resources $resources) {
 		
-		$this->_resources = $resources;
+		$this->resources = $resources;
 		
 	}
 	
@@ -67,7 +67,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function getResources() {
 		
-		return $this->_resources;
+		return $this->resources;
 		
 	}
 	
@@ -76,7 +76,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function addBuilding(StateEconomy $entityState) {
 		
-		$this->_buildings[$entityState->getTechnology()->getType()] = $entityState;
+		$this->buildings[$entityState->getTechnology()->getType()] = $entityState;
 		
 	}
 	
@@ -85,7 +85,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function getBuildings() {
 		
-		return $this->_buildings;
+		return $this->buildings;
 		
 	}
 	
@@ -94,7 +94,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function addResearch(StateEconomy $entityState) {
 		
-		$this->_research[$entityState->getTechnology()->getType()] = $entityState;
+		$this->research[$entityState->getTechnology()->getType()] = $entityState;
 		
 	}
 	
@@ -103,7 +103,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function getResearch() {
 		
-		return $this->_research;
+		return $this->research;
 		
 	}
 	
@@ -112,7 +112,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function addShip(StateCombat $entityState) {
 		
-		$this->_ships[$entityState->getTechnology()->getType()] = $entityState;
+		$this->ships[$entityState->getTechnology()->getType()] = $entityState;
 		
 	}
 	
@@ -121,7 +121,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function getShips() {
 		
-		return $this->_ships;
+		return $this->ships;
 		
 	}
 	
@@ -130,7 +130,7 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function addDefence(StateCombat $entityState) {
 		
-		$this->_defence[$entityState->getTechnology()->getType()] = $entityState;
+		$this->defence[$entityState->getTechnology()->getType()] = $entityState;
 		
 	}
 	
@@ -139,8 +139,21 @@ class SpiedPlayer extends ReportPlayer {
 	 */
 	public function getDefence() {
 		
-		return $this->_defence;
+		return $this->defence;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'resources' => $this->resources,
+			'buildings' => $this->buildings,
+			'research' => $this->research,
+			'ships' => $this->ships,
+			'defence' => $this->defence
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/SpyReport/SpiedPlayer.php
+++ b/src/OGetIt/Report/SpyReport/SpiedPlayer.php
@@ -26,7 +26,7 @@ use OGetIt\Technology\State\StateEconomy;
 use OGetIt\Technology\State\StateCombat;
 use OGetIt\Report\ReportPlayer;
 
-class SpiedPlayer extends ReportPlayer implements \JsonSerializable {
+class SpiedPlayer extends ReportPlayer {
 		
 	/**
 	 * @var Resources

--- a/src/OGetIt/Report/SpyReport/SpyReport.php
+++ b/src/OGetIt/Report/SpyReport/SpyReport.php
@@ -30,42 +30,42 @@ use OGetIt\Technology\State\StateEconomy;
 use OGetIt\Common\OGetIt\Common;
 use OGetIt\Report\Report;
 
-class SpyReport extends Report {
+class SpyReport extends Report implements \JsonSerializable {
 	
 	/**
 	 * @var integer
 	 */
-	private $_activity;
+	private $activity;
 	
 	/**
 	 * @var ReportPlayer
 	 */
-	private $_attacker;
+	private $attacker;
 
 	/**
 	 * @var SpiedPlayer
 	 */
-	private $_defender;
+	private $defender;
 
 	/**
 	 * @var integer
 	 */
-	private $_loot_percentage;
+	private $loot_percentage;
 
 	/**
 	 * @var integer
 	 */
-	private $_spy_fail_chance;
+	private $spy_fail_chance;
 
 	/**
 	 * @var integer
 	 */
-	private $_total_defense_count;
+	private $total_defense_count;
 
 	/**
 	 * @var integer
 	 */
-	private $_total_ship_count;
+	private $total_ship_count;
 	
 	/**
 	 * @param string $api_data
@@ -165,20 +165,20 @@ class SpyReport extends Report {
 		
 		parent::__construct($id, $time, $timestamp);
 
-		$this->_activity = $activity;
+		$this->activity = $activity;
 		
-		$this->_attacker = new ReportPlayer($attacker_name);
-		$this->_attacker->setPlanet(new Planet($attacker_planet_type, $attacker_planet_coordinates, $attacker_planet_name));
-		$this->_attacker->setAlliance(new Alliance($attacker_alliance_tag, $attacker_alliance_name));
+		$this->attacker = new ReportPlayer($attacker_name);
+		$this->attacker->setPlanet(new Planet($attacker_planet_type, $attacker_planet_coordinates, $attacker_planet_name));
+		$this->attacker->setAlliance(new Alliance($attacker_alliance_tag, $attacker_alliance_name));
 		
-		$this->_defender = new SpiedPlayer($defender_name);
-		$this->_defender->setPlanet(new Planet($defender_planet_type, $defender_planet_coordinates, $defender_planet_name));
-		$this->_defender->setAlliance(new Alliance($defender_alliance_tag, $defender_alliance_name));
+		$this->defender = new SpiedPlayer($defender_name);
+		$this->defender->setPlanet(new Planet($defender_planet_type, $defender_planet_coordinates, $defender_planet_name));
+		$this->defender->setAlliance(new Alliance($defender_alliance_tag, $defender_alliance_name));
 		
-		$this->_loot_percentage = $loot_percentage;
-		$this->_spy_fail_chance = $spy_fail_chance;
-		$this->_total_defense_count = $total_defense_count;
-		$this->_total_ship_count = $total_ship_count;
+		$this->loot_percentage = $loot_percentage;
+		$this->spy_fail_chance = $spy_fail_chance;
+		$this->total_defense_count = $total_defense_count;
+		$this->total_ship_count = $total_ship_count;
 		
 	}
 	
@@ -187,7 +187,7 @@ class SpyReport extends Report {
 	 */
 	public function getActivity() {
 		
-		return $this->_activity;
+		return $this->activity;
 		
 	}
 	
@@ -196,7 +196,7 @@ class SpyReport extends Report {
 	 */
 	public function getAttacker() {
 		
-		return $this->_attacker;
+		return $this->attacker;
 		
 	}
 	
@@ -205,7 +205,7 @@ class SpyReport extends Report {
 	 */
 	public function getDefender() {
 		
-		return $this->_defender;
+		return $this->defender;
 		
 	}
 
@@ -214,7 +214,7 @@ class SpyReport extends Report {
 	 */
 	public function getLootPercentage() {
 		
-		return $this->_loot_percentage;
+		return $this->loot_percentage;
 		
 	}
 	
@@ -223,7 +223,7 @@ class SpyReport extends Report {
 	 */
 	public function getSpyFailChance() {
 		
-		return $this->_spy_fail_chance;
+		return $this->spy_fail_chance;
 		
 	}
 	
@@ -232,7 +232,7 @@ class SpyReport extends Report {
 	 */
 	public function getTotalDefenseCount() {
 		
-		return $this->_total_defense_count;
+		return $this->total_defense_count;
 		
 	}
 	
@@ -241,8 +241,23 @@ class SpyReport extends Report {
 	 */
 	public function getTotalShipCount() {
 		
-		return $this->_total_ship_count;
+		return $this->total_ship_count;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'activity' => $this->activity,
+			'attacker' => $this->attacker,
+			'defender' => $this->defender,
+			'loot_percentage' => $this->loot_percentage,
+			'spy_fail_chance' => $this->spy_fail_chance,
+			'total_defense_count' => $this->total_defense_count,
+			'total_ship_count' => $this->total_ship_count
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Report/SpyReport/SpyReport.php
+++ b/src/OGetIt/Report/SpyReport/SpyReport.php
@@ -30,7 +30,7 @@ use OGetIt\Technology\State\StateEconomy;
 use OGetIt\Common\OGetIt\Common;
 use OGetIt\Report\Report;
 
-class SpyReport extends Report implements \JsonSerializable {
+class SpyReport extends Report {
 	
 	/**
 	 * @var integer

--- a/src/OGetIt/Technology/State/State.php
+++ b/src/OGetIt/Technology/State/State.php
@@ -19,24 +19,23 @@
  */
 namespace OGetIt\Technology\State;
 
-use OGetIt\Common\Value;
 use OGetIt\Common\Value\ChildValue;
 
-abstract class State {
+abstract class State implements \JsonSerializable {
 	
 	use ChildValue;
 	
 	/**
 	 * @var TechnologyCombat
 	 */
-	private $_technology;
+	private $technology;
 	
 	/**
 	 * @param Technology $technology
 	 */
 	public function __construct($technology) {
 		
-		$this->_technology = $technology;
+		$this->technology = $technology;
 		
 	}
 
@@ -45,8 +44,17 @@ abstract class State {
 	 */
 	public function getTechnology() {
 		
-		return $this->_technology;
+		return $this->technology;
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'technology' => $this->technology
+		);
 	}
 	
 }

--- a/src/OGetIt/Technology/State/StateCombat.php
+++ b/src/OGetIt/Technology/State/StateCombat.php
@@ -24,7 +24,7 @@ use OGetIt\Common\Resources;
 use OGetIt\Common\Value;
 use OGetIt\Technology\TechnologyCombat;
 
-class StateCombat extends State implements \JsonSerializable {
+class StateCombat extends State {
 	
 	/**
 	 * @var integer

--- a/src/OGetIt/Technology/State/StateCombat.php
+++ b/src/OGetIt/Technology/State/StateCombat.php
@@ -24,12 +24,12 @@ use OGetIt\Common\Resources;
 use OGetIt\Common\Value;
 use OGetIt\Technology\TechnologyCombat;
 
-class StateCombat extends State {
+class StateCombat extends State implements \JsonSerializable {
 	
 	/**
 	 * @var integer
 	 */
-	private $_count;
+	private $count;
 	
 	/**
 	 * @param TechnologyCombat $technology
@@ -39,7 +39,7 @@ class StateCombat extends State {
 		
 		parent::__construct($technology);
 		
-		$this->_count = $count;
+		$this->count = $count;
 		
 	}
 	
@@ -48,7 +48,7 @@ class StateCombat extends State {
 	 */
 	public function getCount() {
 		
-		return $this->_count;
+		return $this->count;
 		
 	}
 	
@@ -57,7 +57,7 @@ class StateCombat extends State {
 	 */
 	public function addCount($count) {
 		
-		$this->_count += $count;
+		$this->count += $count;
 		
 	}
 	
@@ -66,8 +66,17 @@ class StateCombat extends State {
 	 */
 	public function getValue() {
 				
-		return $this->getTechnology()->getCosts($this->_count);
+		return $this->getTechnology()->getCosts($this->count);
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'count' => $this->count
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Technology/State/StateCombatWithLosses.php
+++ b/src/OGetIt/Technology/State/StateCombatWithLosses.php
@@ -25,14 +25,14 @@ use OGetIt\Common\Value;
 use OGetIt\Technology\TechnologyCombat;
 use OGetIt\Common\Value\ChildLosses;
 
-class StateCombatWithLosses extends StateCombat {
+class StateCombatWithLosses extends StateCombat implements \JsonSerializable {
 	
 	use ChildLosses;
 	
 	/**
 	 * @var integer
 	 */
-	private $_lost;
+	private $lost;
 	
 	/**
 	 * @param TechnologyCombat $technology
@@ -43,7 +43,7 @@ class StateCombatWithLosses extends StateCombat {
 		
 		parent::__construct($technology, $count);
 		
-		$this->_lost = $lost;
+		$this->lost = $lost;
 		
 	}
 	
@@ -52,7 +52,7 @@ class StateCombatWithLosses extends StateCombat {
 	 */
 	public function getLost() {
 		
-		return $this->_lost;
+		return $this->lost;
 		
 	}
 	
@@ -61,7 +61,7 @@ class StateCombatWithLosses extends StateCombat {
 	 */
 	public function addLost($lost) {
 		
-		$this->_lost += $lost;
+		$this->lost += $lost;
 		
 	}
 	
@@ -79,8 +79,17 @@ class StateCombatWithLosses extends StateCombat {
 	 */
 	public function getLosses() {
 		
-		return $this->getTechnology()->getCosts($this->_lost);
+		return $this->getTechnology()->getCosts($this->lost);
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'lost' => $this->lost
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Technology/State/StateCombatWithLosses.php
+++ b/src/OGetIt/Technology/State/StateCombatWithLosses.php
@@ -25,7 +25,7 @@ use OGetIt\Common\Value;
 use OGetIt\Technology\TechnologyCombat;
 use OGetIt\Common\Value\ChildLosses;
 
-class StateCombatWithLosses extends StateCombat implements \JsonSerializable {
+class StateCombatWithLosses extends StateCombat {
 	
 	use ChildLosses;
 	

--- a/src/OGetIt/Technology/State/StateEconomy.php
+++ b/src/OGetIt/Technology/State/StateEconomy.php
@@ -24,12 +24,12 @@ use OGetIt\Common\Resources;
 use OGetIt\Common\Value;
 use OGetIt\Technology\TechnologyEconomy;
 
-class StateEconomy extends State {
+class StateEconomy extends State implements \JsonSerializable {
 	
 	/**
 	 * @var integer
 	 */
-	private $_level;
+	private $level;
 	
 	/**
 	 * @param TechnologyCombat $technology
@@ -39,7 +39,7 @@ class StateEconomy extends State {
 		
 		parent::__construct($technology);
 		
-		$this->_level = $level;
+		$this->level = $level;
 		
 	}
 	
@@ -48,7 +48,7 @@ class StateEconomy extends State {
 	 */
 	public function getLevel() {
 		
-		return $this->_level;
+		return $this->level;
 		
 	}
 	
@@ -57,8 +57,17 @@ class StateEconomy extends State {
 	 */
 	public function getValue() {
 				
-		return $this->getTechnology()->getCosts($this->_level);
+		return $this->getTechnology()->getCosts($this->level);
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'level' => $this->level
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Technology/State/StateEconomy.php
+++ b/src/OGetIt/Technology/State/StateEconomy.php
@@ -24,7 +24,7 @@ use OGetIt\Common\Resources;
 use OGetIt\Common\Value;
 use OGetIt\Technology\TechnologyEconomy;
 
-class StateEconomy extends State implements \JsonSerializable {
+class StateEconomy extends State {
 	
 	/**
 	 * @var integer

--- a/src/OGetIt/Technology/Technology.php
+++ b/src/OGetIt/Technology/Technology.php
@@ -21,17 +21,17 @@ namespace OGetIt\Technology;
 
 use OGetIt\Common\Resources;
 
-abstract class Technology {
+abstract class Technology implements \JsonSerializable {
 	
 	/**
 	 * @var integer
 	 */
-	private $_type;
+	private $type;
 	
 	/**
 	 * @var Resources
 	 */
-	private $_resources;
+	private $resources;
 	
 	/**
 	 * @param integer $type
@@ -41,8 +41,8 @@ abstract class Technology {
 	 */
 	protected function __construct($type, $metal, $crystal, $deuterium, $energy = 0) {
 		
-		$this->_type = $type;
-		$this->_resources = new Resources($metal, $crystal, $deuterium, $energy);
+		$this->type = $type;
+		$this->resources = new Resources($metal, $crystal, $deuterium, $energy);
 		
 	}
 	
@@ -51,7 +51,7 @@ abstract class Technology {
 	 */
 	public function getType() {
 		
-		return $this->_type;
+		return $this->type;
 		
 	}
 	
@@ -60,7 +60,7 @@ abstract class Technology {
 	 */
 	public function getResources() {
 		
-		return $this->_resources;
+		return $this->resources;
 		
 	}
 	
@@ -68,5 +68,15 @@ abstract class Technology {
 	 * @return Resources
 	 */
 	abstract public function getCosts();
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array(
+			'type' => $this->type,
+			'resources' => $this->resources
+		);
+	}
 	
 }

--- a/src/OGetIt/Technology/TechnologyCombat.php
+++ b/src/OGetIt/Technology/TechnologyCombat.php
@@ -20,7 +20,7 @@
 namespace OGetIt\Technology;
 
 use OGetIt\Common\Resources;
-abstract class TechnologyCombat extends Technology implements \JsonSerializable {
+abstract class TechnologyCombat extends Technology {
 
 	/**
 	 * @var integer

--- a/src/OGetIt/Technology/TechnologyCombat.php
+++ b/src/OGetIt/Technology/TechnologyCombat.php
@@ -20,7 +20,7 @@
 namespace OGetIt\Technology;
 
 use OGetIt\Common\Resources;
-abstract class TechnologyCombat extends Technology {
+abstract class TechnologyCombat extends Technology implements \JsonSerializable {
 
 	/**
 	 * @var integer
@@ -92,6 +92,17 @@ abstract class TechnologyCombat extends Technology {
 			$this->getResources()->getDeuterium() * $count	
 		);
 		
+	}
+	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'armour' => $this->ARMOR,
+			'shield' => $this->SHIELD,
+			'weapon' => $this->WEAPON
+		), parent::jsonSerialize());
 	}
 	
 }

--- a/src/OGetIt/Technology/TechnologyEconomy.php
+++ b/src/OGetIt/Technology/TechnologyEconomy.php
@@ -58,4 +58,13 @@ abstract class TechnologyEconomy extends Technology {
 		
 	}
 	
+	/* (non-PHPdoc)
+	 * @see JsonSerializable::jsonSerialize()
+	 */
+	public function jsonSerialize() {
+		return array_merge(array(
+			'power_base' => $this->power_base
+		), parent::jsonSerialize());
+	}
+	
 }


### PR DESCRIPTION
The changes in this branch make it possible to json_encode OGetIt reports.
This can be usefull when you want to use this data in a Javascript application in a user browser.
An other use could be to use OGetIt as a proxy (in PHP) when you want report data in a application that understands JSON.
